### PR TITLE
Jbarno/headless chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 errorShots
 coverage
 .env
+.DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ errorShots
 coverage
 .env
 .DS_STORE
+
+allure-reports/
+wdio-logs/

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "wdio-sauce-service": "^0.4.0",
     "wdio-selenium-standalone-service": "^0.0.8",
     "wdio-spec-reporter": "~0.1.0",
-    "webdriverio": "~4.8.0"
+    "webdriverio": "~4.8.0",
+    "wdio-json-reporter": "~0.2.1"
   },
   "devDependencies": {
     "babel-jest": "~20.0.0",
@@ -44,6 +45,8 @@
     "eslint-config-airbnb-base": "~11.2.0",
     "eslint-plugin-import": "~2.3.0",
     "http-server": "~0.10.0",
-    "jest": "~20.0.0"
+    "jest": "~20.0.0",
+    "allure-commandline": "~2.3.5",
+    "wdio-allure-reporter": "~0.1.2"
   }
 }

--- a/wdio.BUILD.conf.js
+++ b/wdio.BUILD.conf.js
@@ -1,13 +1,6 @@
 const config = require('./wdio.conf.js').config;
 
-config.capabilities = [{
-    browserName: 'chrome',
-    chromeOptions: {
-    args: ['--headless', '--disable-gpu']
-    }
-}];
-
-config.maxInstances = 1;
+config.maxInstances = 5;
 
 config.services = ['selenium-standalone'];
 

--- a/wdio.BUILD.conf.js
+++ b/wdio.BUILD.conf.js
@@ -1,6 +1,12 @@
 const config = require('./wdio.conf.js').config;
 
-config.maxInstances = 5;
+config.reporters = ['allure', 'dot', 'spec', 'json'];
+config.reporterOptions = {
+    outputDir: './wdio-logs/',
+    allure: {
+        outputDir: './allure-reports/allure/'
+    }
+};
 
 config.services = ['selenium-standalone'];
 

--- a/wdio.BUILD.conf.js
+++ b/wdio.BUILD.conf.js
@@ -1,10 +1,13 @@
 const config = require('./wdio.conf.js').config;
 
 config.capabilities = [{
-    browserName: 'firefox',
+    browserName: 'chrome',
+    chromeOptions: {
+    args: ['--headless', '--disable-gpu']
+    }
 }];
 
-config.maxInstances = 5;
+config.maxInstances = 1;
 
 config.services = ['selenium-standalone'];
 

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -5,7 +5,10 @@ const {
     BASE_URL,
     SAUCELAB_USER,
     SAUCELAB_KEY,
-    PROJECT
+    PROJECT,
+    CHROME,
+    CHROME_HEADLESS,
+    FIREFOX
 } = process.env;
 
 const specsPath = `./src/features/${PROJECT}/**/*.feature`;
@@ -15,8 +18,15 @@ if (!PROJECT) {
     process.exit();
 }
 if (!BASE_URL) {
-    console.error('Please provide a BASE_URL in the ".env" file (e.g. https://gdc-portal-staging.datacommons.io)');
+    console.error('Please provide a BASE_URL in the ".env" file (e.g. https://portal.gdc.cancer.gov/)');
     process.exit();
+}
+
+if (!CHROME && !CHROME_HEADLESS && !FIREFOX ) {
+    console.error('Please specify a browser type in ".env" file (non empty string wins)');
+    process.exit();
+} else {
+    console.log("Running: " + (CHROME? "chrome, ": "") + (CHROME_HEADLESS? "chrome_headless, ": "") + (FIREFOX? "firefox": ""));
 }
 
 exports.config = {
@@ -65,14 +75,23 @@ exports.config = {
     // out the Sauce Labs platform configurator - a great tool to configure your
     // capabilities: https://docs.saucelabs.com/reference/platforms-configurator
     //
-    capabilities: [{
-        // maxInstances can get overwritten per capability. So if you have an
-        // in-house Selenium grid with only 5 firefox instance available you can
-        // make sure that not more than 5 instance gets started at a time.
-        maxInstances: 5,
-        //
-        browserName: 'chrome',
-    }],
+    capabilities: [
+        CHROME && {
+            maxInstances: 5,
+            browserName: 'chrome',
+        },
+        CHROME_HEADLESS && {
+            maxInstances: 5,
+            browserName: 'chrome',
+            chromeOptions: {
+                args: ['--headless', '--disable-gpu', '--window-size=1280,800'],
+            }
+        },
+        FIREFOX && {
+            maxInstances: 5,
+            browserName: 'firefox',
+        }
+    ],
     //
     // ===================
     // Test Configurations


### PR DESCRIPTION
# Contribution description
> Trying to make it so we can run chrome headlessly (eventually within new clusters)
> For some odd reason this will always run firefox along with the other browsers. @cheapsteak I don't know why
>> I tried to add some logging in the build.conf.js and never see that it never spits out firefox. Idk does BUILD.conf.js get cached somwhere?

# Pull request checklist
- [ ] Contributed code respects the [editorconfig rules](.editorconfig)
- [ ] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [ ] Contributed code passes the unit tests
- [ ] Added rules are described in the [readme file](README.md)
- [ ] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
