### PR TITLE
Allure works, but treats steps as tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ errorShots
 coverage
 .env
 .DS_STORE
+
+allure-reports/
+wdio-logs/

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "wdio-sauce-service": "^0.4.0",
     "wdio-selenium-standalone-service": "^0.0.8",
     "wdio-spec-reporter": "~0.1.0",
-    "webdriverio": "~4.8.0"
+    "webdriverio": "~4.8.0",
+    "wdio-json-reporter": "~0.2.1"
   },
   "devDependencies": {
     "babel-jest": "~20.0.0",
@@ -44,6 +45,8 @@
     "eslint-config-airbnb-base": "~11.2.0",
     "eslint-plugin-import": "~2.3.0",
     "http-server": "~0.10.0",
-    "jest": "~20.0.0"
+    "jest": "~20.0.0",
+    "allure-commandline": "~2.3.5",
+    "wdio-allure-reporter": "~0.1.2"
   }
 }

--- a/wdio.BUILD.conf.js
+++ b/wdio.BUILD.conf.js
@@ -1,6 +1,12 @@
 const config = require('./wdio.conf.js').config;
 
-config.maxInstances = 5;
+config.reporters = ['allure', 'dot', 'spec', 'json'];
+config.reporterOptions = {
+    outputDir: './wdio-logs/',
+    allure: {
+        outputDir: './allure-reports/allure/'
+    }
+};
 
 config.services = ['selenium-standalone'];
 


### PR DESCRIPTION
# Contribution description
> Make the test outputs something pretty. To serve up a local run run:
>> `allure server /allure-reports/allure`

Needs java8 on your machine to run, but npm should handle the allure commandline 

# Pull request checklist
- [ ] Contributed code respects the [editorconfig rules](.editorconfig)
- [ ] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [ ] Contributed code passes the unit tests
- [ ] Added rules are described in the [readme file](README.md)
- [ ] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
